### PR TITLE
 Fix misuse of unsafe.Pointer in buffer.go

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -34,7 +34,7 @@ type Buffer struct {
 	bcap int64
 
 	// temp?
-	obuf uintptr
+	obuf unsafe.Pointer
 
 	sync.Mutex
 }
@@ -404,15 +404,16 @@ func (b *Buffer) WriteBytes(off int64, data []byte) {
 	}*/
 
 	var (
-		p = uintptr(off) + b.obuf
+		p = unsafe.Pointer(uintptr(b.obuf) + uintptr(off))
+		offset uintptr
 		i = int64(0)
 		n = int64(len(data))
 	)
 	{
 	write_loop:
-		*(*byte)(unsafe.Pointer(p)) = data[i]
+		*(*byte)(unsafe.Pointer(uintptr(p) + offset)) = data[i]
 		i++
-		p++
+		offset++
 		if i < n {
 
 			goto write_loop
@@ -1149,7 +1150,7 @@ func (b *Buffer) Refresh() {
 
 	if len(b.buf) > 0 {
 
-		b.obuf = (uintptr)(unsafe.Pointer(&b.buf[0]))
+		b.obuf = unsafe.Pointer(&b.buf[0])
 
 	}
 


### PR DESCRIPTION
According to:
https://golang.org/pkg/unsafe/#Pointer

Usage of unsafe.Pointer should be implemented with defined pattern to avoid becoming invalid in the future.